### PR TITLE
Pipe support

### DIFF
--- a/inc/VideoYUV.hpp
+++ b/inc/VideoYUV.hpp
@@ -69,7 +69,7 @@ public:
 	// readOneFrame() needs to be called before getLuma()
 	void getLuma(cv::Mat& luma, int type = CV_8UC1);
 private:
-	int file;		// file stream
+	FILE* file;		// file stream
 	int nbframes;		// number of frames
 	int height;		// height
 	int width;		// width

--- a/src/VideoYUV.cpp
+++ b/src/VideoYUV.cpp
@@ -26,7 +26,7 @@
 
 VideoYUV::VideoYUV(const char *f, int h, int w, int nbf, int chroma_format)
 {
-	file = open(f, O_RDONLY | O_BINARY);
+	file = fopen(f, "rb");
 	if (!file) {
 		fprintf(stderr, "readOneFrame: cannot open input file (%s)\n", f);
 		exit(EXIT_FAILURE);
@@ -80,7 +80,7 @@ VideoYUV::VideoYUV(const char *f, int h, int w, int nbf, int chroma_format)
 VideoYUV::~VideoYUV()
 {
 	delete[] data;
-	close(file);
+	fclose(file);
 }
 
 bool VideoYUV::readOneFrame()
@@ -92,7 +92,7 @@ bool VideoYUV::readOneFrame()
 		if (read_size <= 0)
 			continue;
 		for (int i=0; i<comp_height[j]; i++) {
-			if (read(file, ptr_data, static_cast<size_t>(read_size)) != read_size) {
+			if (fread(ptr_data, 1, static_cast<size_t>(read_size), file) != static_cast<size_t>(read_size)) {
 				fprintf(stderr, "readOneFrame: cannot read %d bytes from input file, unexpected EOF.\n", read_size);
 				return false;
 			}

--- a/src/VideoYUV.cpp
+++ b/src/VideoYUV.cpp
@@ -26,7 +26,11 @@
 
 VideoYUV::VideoYUV(const char *f, int h, int w, int nbf, int chroma_format)
 {
-	file = fopen(f, "rb");
+	if(strcmp(f, "-") == 0)
+		file = stdin;
+	else
+		file = fopen(f, "rb");
+		
 	if (!file) {
 		fprintf(stderr, "readOneFrame: cannot open input file (%s)\n", f);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Read function is changed to `fread` and `stdin` input is now supported.

Reading input from named pipe is faster than reading raw YUV files from HDD (in my case 15s vs 120s).

Closes #6 